### PR TITLE
New API Route to serve images

### DIFF
--- a/fullstack-app/package-lock.json
+++ b/fullstack-app/package-lock.json
@@ -67,6 +67,7 @@
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "shadcn": "^2.3.0",
+        "sharp": "^0.33.5",
         "superjson": "^2.2.1",
         "tailwind-merge": "^3.0.1",
         "tailwindcss": "^4.0.4",
@@ -3271,17 +3272,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@huggingface/transformers/node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@huggingface/transformers/node_modules/flatbuffers": {
       "version": "25.1.24",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.1.24.tgz",
@@ -3437,47 +3427,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
       }
     },
     "node_modules/@huggingface/transformers/node_modules/tar": {
@@ -9602,13 +9551,13 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.4.0.tgz",
-      "integrity": "sha512-9Ous7UlnKbe3fMi7Y+qh0DwAup6A1JkYgPnjvMDNOlmnxNRQvQ/7Nst+OnUQKzk0iAT0m9BisbDVp9gCv8+ETA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.5.1.tgz",
+      "integrity": "sha512-LvfVNDcWLw2AnIw5f2mWUgumW3I3N/WYGiWeimhQC1Ybt71n2FjlS9GJKeCnFeg1MKZHxzIFmpFnBXDI+sBeFg==",
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
-        "bare": ">=1.6.0"
+        "bare": ">=1.14.0"
       }
     },
     "node_modules/bare-path": {
@@ -10149,6 +10098,38 @@
       },
       "optionalDependencies": {
         "onnxruntime-node": "1.14.0"
+      }
+    },
+    "node_modules/chromadb-default-embed/node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chromadb-default-embed/node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -19435,16 +19416,6 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
-    "node_modules/next/node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -19471,46 +19442,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/next/node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
       }
     },
     "node_modules/no-case": {
@@ -22664,26 +22595,42 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.32.6",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.4",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^3.0.4",
-        "tunnel-agent": "^0.6.0"
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
       },
       "engines": {
-        "node": ">=14.15.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
       }
     },
     "node_modules/sharp/node_modules/detect-libc": {

--- a/fullstack-app/package.json
+++ b/fullstack-app/package.json
@@ -93,6 +93,7 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "shadcn": "^2.3.0",
+    "sharp": "^0.33.5",
     "superjson": "^2.2.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss": "^4.0.4",

--- a/fullstack-app/src/components/modules/dashboard/DocumentCard.tsx
+++ b/fullstack-app/src/components/modules/dashboard/DocumentCard.tsx
@@ -36,15 +36,21 @@ export function DocumentCard(props: DocumentCardProps) {
   const t = useTranslations('document-manager');
   const format = useFormatter();
   const docIsUploading = 'onCancelButtonClick' in props;
-  const imageUrl = !isStringEmpty(props.doc.imageUrl)
-    ? props.doc.imageUrl.replace('/public/', '/')
-    : '/default-doc-image.jpg';
+  const imageUrl = isStringEmpty(props.doc.imageUrl)
+    ? 'public/default-doc-image.jpg'
+    : props.doc.imageUrl;
 
   return (
     <Card className={cn('max-w-[16rem]', docIsUploading && 'animate-pulse')}>
       <CardContent className="p-0">
         <Image
           src={imageUrl}
+          // We are optimizing the images ourselves because the image may
+          // not be in the public folder at compile time, and thus Next.js
+          // cannot retrieve it if it's passed as a relative url.
+          loader={({src, width, quality}) =>
+            `/api/serveImage?url=${src}&w=${width}&q=${quality ?? 75}`
+          }
           alt={t('image-alt')}
           className="aspect-4/3 rounded-t-xl object-contain md:aspect-1/1"
           width={400}

--- a/fullstack-app/src/pages/api/serveImage.ts
+++ b/fullstack-app/src/pages/api/serveImage.ts
@@ -1,0 +1,104 @@
+import {
+  fileExists,
+  getFile,
+  validateAndResolvePath,
+} from '@/server/utils/fileStorage';
+import type {APIRouteErrorResponse} from '@/types/APIRouteErrorResponse';
+import {acceptedImageTypes} from '@/types/UploadNewDocumentPayload';
+import {isStringEmpty, nonEmptyStringSchema} from '@/utils/strings';
+import mime from 'mime';
+import type {NextApiRequest, NextApiResponse} from 'next';
+import path from 'node:path';
+import {env} from 'node:process';
+import sharp from 'sharp';
+import {z} from 'zod';
+
+const DEFAULT_QUALITY = 75;
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+// TODO: This should go inside a Trigger.dev task because it can be CPU intensive
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({
+      message: 'Method not allowed',
+      data: {code: 'METHOD_NOT_SUPPORTED'},
+    } satisfies APIRouteErrorResponse);
+  }
+
+  const queryParams = z
+    .object({
+      url: nonEmptyStringSchema.refine(
+        (val) => !isStringEmpty(validateAndResolvePath(val)),
+        (val) => ({
+          message: `Invalid supplied file URL: ${val}`,
+        })
+      ),
+      w: z.coerce.number().min(1).int().optional(),
+      h: z.coerce.number().min(1).int().optional(),
+      q: z.coerce.number().min(0).max(100).optional().default(DEFAULT_QUALITY),
+    })
+    .parse(req.query);
+
+  if (!(await fileExists(queryParams.url))) {
+    return res.status(404).json({
+      message: 'Image not found',
+      data: {code: 'NOT_FOUND'},
+    } satisfies APIRouteErrorResponse);
+  }
+
+  try {
+    const filePath = validateAndResolvePath(queryParams.url);
+    const mimeType = mime.getType(path.extname(filePath));
+
+    if (mimeType == null || !acceptedImageTypes.includes(mimeType)) {
+      return res.status(400).json({
+        message: 'Invalid file type requested, you can only request images',
+        data: {code: 'BAD_REQUEST'},
+      } satisfies APIRouteErrorResponse);
+    }
+
+    const file = await getFile({
+      filePath,
+      mimeType,
+    });
+
+    const fileBuffer = Buffer.from(await file.arrayBuffer());
+
+    const image = sharp(fileBuffer)
+      .resize(queryParams.w, queryParams.h, {
+        fit: 'inside',
+      })
+      .webp({quality: queryParams.q});
+
+    const resizedBuffer = await image.toBuffer();
+
+    if (env.NODE_ENV === 'development') {
+      const metadata = await sharp(resizedBuffer).metadata();
+
+      console.log('Image served with following characteristics: ', {
+        ...metadata,
+        quality: queryParams.q,
+      });
+    }
+
+    return res
+      .status(200)
+      .setHeader('Content-Type', 'image/webp')
+      .send(resizedBuffer);
+  } catch (error) {
+    console.error('Error sending image: ', error);
+
+    return res.status(500).json({
+      message: 'Error sending image',
+      data: {code: 'INTERNAL_SERVER_ERROR'},
+    } satisfies APIRouteErrorResponse);
+  }
+}

--- a/fullstack-app/src/server/utils/fileStorage.ts
+++ b/fullstack-app/src/server/utils/fileStorage.ts
@@ -32,6 +32,7 @@ export const allowedAbsoluteDirPaths = {
   logLlmAnswers: ensureAbsolutePath(
     path.join(isDevEnv ? 'public/temp' : 'temp', 'logs/llm-answers')
   ),
+  public: ensureAbsolutePath(path.join(process.cwd(), 'public')),
   appTempDir: ensureAbsolutePath(path.join(os.tmpdir(), 'chat-with-manuals')),
 } as const;
 


### PR DESCRIPTION
Seems in production build Next.js cannot serve, even from /public folder, any image it has not been
there during compile time. So we had to develop a specific API Route to serve the optimized images
users upload. For compile time images we don't need to use a special loader.
